### PR TITLE
Change Sisu dccrg library path to new version.

### DIFF
--- a/MAKE/Makefile.sisu_gcc
+++ b/MAKE/Makefile.sisu_gcc
@@ -82,7 +82,7 @@ INC_PROFILE = -I$(LIBRARY_PREFIX)/mpich2/$(MPT_VERSION)/$(CC_BRAND)/$(CC_BRAND_V
 #header libraries
 
 INC_EIGEN = -I$(LIBRARY_PREFIX)/eigen/
-INC_DCCRG = -I$(LIBRARY_PREFIX)/dccrg/
+INC_DCCRG = -I$(LIBRARY_PREFIX)/dccrg_new_neighbours/
 INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/vectorclass
 INC_FSGRID = -I$(LIBRARY_PREFIX)/fsgrid
 


### PR DESCRIPTION
This way, old versions of the code remain compatible with the library version
before the neighbour interface update. We can then merge pull request #380 without breaking anything.

Testing with the testpackage on sisu, it appears the 30% speedup was an artefact of my workplace machine though. On Sisu, no performance enhancement was visible. Ah well.